### PR TITLE
Add Code Coverage Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -34,6 +34,8 @@ jobs:
             name: Ballerina Internal Log
             path: file-ballerina/ballerina-internal.log
             if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Archive Code Coverage JSON
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,9 @@ jobs:
             name: Ballerina Internal Log
             path: file-ballerina/ballerina-internal.log
             if-no-files-found: ignore
+      - name: Generate Codecov Report
+        if:  github.event_name == 'pull_request'
+        uses: codecov/codecov-action@v1
       - name: Archive Code Coverage JSON
         uses: actions/upload-artifact@v2
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: no
+
+fixes:
+  - "ballerina/file/*/::file-ballerina/"
+
+ignore:
+  - "**/tests"
+  - "**/testutils"


### PR DESCRIPTION
## Purpose
> Introducing Codecov code coverage report publishing to the file repository
## Goals
> Publishing the testerina generated code coverage xml to Codecov triggered via GitHub action of PR

## Approach
>A new job is inserted to Pull request GitHub actions that publishes the XML report to Codecov.
>These jobs trigger on merge to master or pull request and CodeCov generates a descriptive code coverage report.
 >Codecov also adds comments to any PR made based on the code coverage changes between commits