### PR TITLE
Set flag to enable Jacoco Coverage XML generation

### DIFF
--- a/file-ballerina/build.gradle
+++ b/file-ballerina/build.gradle
@@ -157,7 +157,7 @@ def needSeparateTest = false
 def needBuildWithTest = false
 def needPublishToCentral = false
 def needPublishToLocalCentral = false
-def testCoverageParam = "--code-coverage --jacoco-xml --includes=org.ballerinalang.stdlib.file.*:ballerina.file.*"
+def testCoverageParam = "--code-coverage --jacoco-xml --includes=*"
 
 task initializeVariables {
     if (project.hasProperty("groups")) {

--- a/file-ballerina/build.gradle
+++ b/file-ballerina/build.gradle
@@ -157,6 +157,7 @@ def needSeparateTest = false
 def needBuildWithTest = false
 def needPublishToCentral = false
 def needPublishToLocalCentral = false
+def testCoverageParam = "--code-coverage --jacoco-xml --includes=org.ballerinalang.stdlib.file.*:ballerina.file.*"
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -192,7 +193,7 @@ task initializeVariables {
         }
 
         if (graph.hasTask(":${packageName}-ballerina:test")) {
-            testParams = "--code-coverage --includes=*"
+            testParams = testCoverageParam
         } else {
             testParams = "--skip-tests"
         }
@@ -208,9 +209,9 @@ task ballerinaBuild {
                 workingDir project.projectDir
                 environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
+                    commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test ${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
                 } else {
-                    commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
+                    commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test ${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams}"
                 }
             }
         }


### PR DESCRIPTION
Set flag to enable Jacoco Coverage XML generation. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30381