### PR TITLE
Fix missing error handling in file:copy for non-existent destination directory

### DIFF
--- a/ballerina/tests/file-test.bal
+++ b/ballerina/tests/file-test.bal
@@ -315,9 +315,22 @@ function testCopyFileReplaceTrue() {
 @test:Config {}
 function testCopyFileNonExistSource() {
     error? copyResult = copy("tests/resources/no-file.txt", tmpdir + noFile);
+    io:println(copyResult);
     if copyResult is error {
         string expectedErrMsg = "File not found";
         test:assertTrue(copyResult.message().includes(expectedErrMsg));
+    }
+}
+
+@test:Config {}
+function testCopyFileNonExistDir() {
+    error? copyResult = copy(srcFile, noDir + copyFile);
+    io:println(copyResult);
+    if copyResult is error {
+        string expectedErrMsg = "The target directory does not exist";
+        test:assertTrue(copyResult.message().includes(expectedErrMsg));
+    } else {
+        test:assertFail("File copy succeeded to a non-existent destination directory!");
     }
 }
 

--- a/ballerina/tests/file-test.bal
+++ b/ballerina/tests/file-test.bal
@@ -315,7 +315,6 @@ function testCopyFileReplaceTrue() {
 @test:Config {}
 function testCopyFileNonExistSource() {
     error? copyResult = copy("tests/resources/no-file.txt", tmpdir + noFile);
-    io:println(copyResult);
     if copyResult is error {
         string expectedErrMsg = "File not found";
         test:assertTrue(copyResult.message().includes(expectedErrMsg));
@@ -325,7 +324,6 @@ function testCopyFileNonExistSource() {
 @test:Config {}
 function testCopyFileNonExistDir() {
     error? copyResult = copy(srcFile, noDir + copyFile);
-    io:println(copyResult);
     if copyResult is error {
         string expectedErrMsg = "The target directory does not exist";
         test:assertTrue(copyResult.message().includes(expectedErrMsg));

--- a/native/src/main/java/io/ballerina/stdlib/file/nativeimpl/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/file/nativeimpl/Utils.java
@@ -335,6 +335,8 @@ public class Utils {
             Path newFile = target.resolve(source.relativize(file));
             try {
                 Files.copy(file, newFile, copyOptions);
+            } catch (NoSuchFileException e) {
+                throw e;
             } catch (Exception e) {
                 log.debug(e.getMessage());
                 return SKIP_SUBTREE; // skip processing


### PR DESCRIPTION
## Purpose

Fixes [https://github.com/ballerina-platform/ballerina-library/issues/5738](https://github.com/ballerina-platform/ballerina-library/issues/5738)

## Examples

With the implementation of this PR, the code below returns `FileNotFoundError` if the directory `foo` does not exist.

```bal
import ballerina/file;
import ballerina/io;

public function main() returns error? {
    string sourcePath = "insert.sql";
    string destPath = "foo/insert.sql";
    file:Error? copy = file:copy(sourcePath, destPath);
    if copy is file:Error {
        io:println(copy.message());
    }
}

```
Output for the above code:

```bash
The target directory does not exist: insert.sql -> foo/insert.sql"
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
