### PR TITLE
Fix `file:copy` to return error when target file exists without `REPLACE_EXISTING`

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina/tests/file-test.bal
+++ b/ballerina/tests/file-test.bal
@@ -247,7 +247,8 @@ function testCreateDirWithoutParentDir() {
 @test:Config {}
 function testCopyFileToNonExistentFileReplaceFalse() {
     error? removeResult = remove(tmpdir + copyFile);
-    if removeResult is error {
+    if removeResult is error && removeResult !is FileNotFoundError {
+        io:println(">>>> " + removeResult.toString());
         test:assertFail("Error removing test resource!");
     }
 

--- a/ballerina/tests/file-test.bal
+++ b/ballerina/tests/file-test.bal
@@ -244,14 +244,18 @@ function testCreateDirWithoutParentDir() {
     }
 }
 
-@test:Config {}
-function testCopyFileToNonExistentFileReplaceFalse() {
-    error? removeResult = remove(tmpdir + copyFile);
-    if removeResult is error && removeResult !is FileNotFoundError {
-        io:println(">>>> " + removeResult.toString());
-        test:assertFail("Error removing test resource!");
+function RemoveCopySource() returns error? {
+    boolean|error isSourceExists = test(tmpdir + copyFile, EXISTS);
+    if isSourceExists is boolean && isSourceExists {
+        check remove(tmpdir + copyFile);
     }
+}
 
+@test:Config {
+    before: RemoveCopySource,
+    dependsOn: [testRemove, testFileExists]
+}
+function testCopyFileToNonExistentFileReplaceFalse() {
     MetaData|error srcmetadata = getMetaData(srcFile);
     if srcmetadata is MetaData {
         srcFileLength = srcmetadata.size;

--- a/native/src/main/java/io/ballerina/stdlib/file/nativeimpl/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/file/nativeimpl/Utils.java
@@ -299,6 +299,9 @@ public class Utils {
         } catch (NoSuchFileException ex) {
             return FileUtils.getBallerinaError(FileConstants.FILE_NOT_FOUND_ERROR,
                     "The target directory does not exist: " + ex.getMessage());
+        } catch (FileAlreadyExistsException ex) {
+            return FileUtils.getBallerinaError(FileConstants.INVALID_OPERATION_ERROR,
+                    "The target file already exists: " + ex.getMessage());
         } catch (IOException ex) {
             return FileUtils.getBallerinaError(FileConstants.FILE_SYSTEM_ERROR,
                     "An error occurred when copying the file/s: " + ex.getMessage());
@@ -335,7 +338,7 @@ public class Utils {
             Path newFile = target.resolve(source.relativize(file));
             try {
                 Files.copy(file, newFile, copyOptions);
-            } catch (NoSuchFileException e) {
+            } catch (IOException e) {
                 throw e;
             } catch (Exception e) {
                 log.debug(e.getMessage());


### PR DESCRIPTION
## Purpose

Fixes [https://github.com/ballerina-platform/ballerina-library/issues/8316](https://github.com/ballerina-platform/ballerina-library/issues/8316)

## Examples

With this implementation below code returns `InvalidOperationError`, if `temp2.txt` already exists.

```bal
public function main() returns error? {
    string sourcePath = "temp1.txt";
    string destPath = "temp2.txt";
    file:Error? copy = file:copy(sourcePath, destPath);
    if copy is file:Error {
        io:println(copy.message());
    }
    io:println("done");
}
``` 

Output for the above code:

```
error InvalidOperationError ("The target file already exists: temp2.txt")
```

## Tests

I have added 4 tests to reflect the below scenarios.

1. `testCopyFileToNonExistentFileReplaceFalse` - file should be copied
2. `testCopyFileToExistingFileReplaceFalse` - return error
3. `testCopyFileToExistingFileReplaceTrue` - file replaced
4. `testCopyFileToNonExistentFileReplaceTrue` - file created

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `file:copy` to return `INVALID_OPERATION_ERROR` when the target file exists and `REPLACE_EXISTING` is not specified.
- Improved propagation of file-copy I/O errors.
- Added tests for existing and non-existing targets with replacement enabled and disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->