### PR TITLE
Allow optional error? return type in file listener remote functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following code sample shows how to create a `Service` with the `onCreate` re
 ```ballerina
 service "localObserver" on inFolder {
 
-    remote function onCreate(file:FileEvent m) {
+    remote function onCreate(file:FileEvent m)  returns error? {
         string msg = "Create: " + m.name;
         log:printInfo(msg);
     }

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -38,7 +38,7 @@ The following code sample shows how to create a `Service` with the `onCreate` re
 ```ballerina
 service "localObserver" on inFolder {
 
-    remote function onCreate(file:FileEvent m) {
+    remote function onCreate(file:FileEvent m) returns error? {
         string msg = "Create: " + m.name;
         log:printInfo(msg);
     }

--- a/changelog.md
+++ b/changelog.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [Add static code rules](https://github.com/ballerina-platform/ballerina-library/issues/7283)
+
+- [Allow optional `error?` return type in file listener remote functions](https://github.com/ballerina-platform/ballerina-library/issues/7596)
 
 ### Changed
 
-- [Change the listener configuration as an included parameter](https://github.com/ballerina-platform/ballerina-library/issues/7494)
 - [Update the static analysis tests to use scan tool's test API](https://github.com/ballerina-platform/ballerina-library/issues/8249)
+- [Fix missing error handling in file:copy for non-existent destination directory](https://github.com/ballerina-platform/ballerina-library/issues/5738)
+
+## [1.12.0]
+
+### Added
+- [Add static code rules](https://github.com/ballerina-platform/ballerina-library/issues/7283)
+
+## [1.11.0]
+
+### Added
+- [Change the listener configuration as an included parameter](https://github.com/ballerina-platform/ballerina-library/issues/7494)
 
 ## [1.10.0] - 2024-08-20
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,12 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Update the static analysis tests to use scan tool's test API](https://github.com/ballerina-platform/ballerina-library/issues/8249)
 - [Fix missing error handling in file:copy for non-existent destination directory](https://github.com/ballerina-platform/ballerina-library/issues/5738)
 
-## [1.12.0]
+## [1.12.0] - 2025-03-12
 
 ### Added
 - [Add static code rules](https://github.com/ballerina-platform/ballerina-library/issues/7283)
 
-## [1.11.0]
+## [1.11.0] - 2025-02-17
 
 ### Added
 - [Change the listener configuration as an included parameter](https://github.com/ballerina-platform/ballerina-library/issues/7494)

--- a/compiler-plugin-test/src/test/java/io/ballerina/stdlib/file/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-test/src/test/java/io/ballerina/stdlib/file/compiler/CompilerPluginTest.java
@@ -145,7 +145,7 @@ public class CompilerPluginTest {
     @Test
     public void testCompilerPluginWithReturn() {
         Package currentPackage = loadPackage("package_07");
-        String errMsg = "return types are not allowed in the remote function `onCreate`";
+        String errMsg = "invalid return type in the remote function `onCreate`, only `error?` return type is allowed";
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.errors().size(), 1);
@@ -156,14 +156,23 @@ public class CompilerPluginTest {
     @Test
     public void testCompilerPluginWithDummyAndMultipleService() {
         Package currentPackage = loadPackage("package_08");
-        String errMsg = "return types are not allowed in the remote function `onCreate`";
-        String errMsg1 = "return types are not allowed in the remote function `onCreate`";
+        String errMsg = "invalid return type in the remote function `onCreate`, only `error?` return type is allowed";
+        String errMsg1 = "invalid return type in the remote function `onCreate`, only `error?` return type is allowed";
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.errors().size(), 2);
         Object[] errors = diagnosticResult.errors().toArray();
         Assert.assertTrue(errors[0].toString().contains(errMsg));
         Assert.assertTrue(errors[1].toString().contains(errMsg1));
+    }
+
+    @Test
+    public void testCompilerPluginWithErrorReturn() {
+        Package currentPackage = loadPackage("package_11");
+        PackageCompilation compilation = currentPackage.getCompilation();
+
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errors().size(), 0);
     }
 
     private Package loadPackage(String path) {

--- a/compiler-plugin-test/src/test/resources/test-src/package_11/Ballerina.toml
+++ b/compiler-plugin-test/src/test/resources/test-src/package_11/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "file_test"
+name = "package_11"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-test/src/test/resources/test-src/package_11/file_service.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/package_11/file_service.bal
@@ -1,6 +1,6 @@
-// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
+// WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at

--- a/compiler-plugin-test/src/test/resources/test-src/package_11/file_service.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/package_11/file_service.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/file;
+
+listener file:Listener localFolder = new ({
+    path: "src/test/resources",
+    recursive: false
+});
+
+service "filesystem" on localFolder {
+
+    remote function onCreate(file:FileEvent m) returns error? {
+    }
+
+    remote function onModify(file:FileEvent m) returns error? {
+    }
+
+    remote function onDelete(file:FileEvent m) {
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/file/compiler/ErrorCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/file/compiler/ErrorCodes.java
@@ -28,7 +28,7 @@ public enum ErrorCodes {
     FILE_102("missing remote keyword in the remote function `{0}`", "FILE_102"),
     FILE_103("invalid function name `{0}`, file listener only supports " +
             "`onCreate`, `onModify` and `onDelete` remote functions", "FILE_103"),
-    FILE_104("return types are not allowed in the remote function `{0}`", "FILE_104"),
+    FILE_104("invalid return type in the remote function `{0}`, only `error?` return type is allowed", "FILE_104"),
     FILE_105("the remote function should only contain file:FileEvent parameter", "FILE_105"),
     FILE_106("at least a single remote function required in the service", "FILE_106");
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/file/compiler/FileServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/file/compiler/FileServiceValidator.java
@@ -140,13 +140,12 @@ public class FileServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private boolean isErrorOrNilType(Node typeNode) {
-        // Allow `error?` which is an OptionalTypeDescriptorNode wrapping an error type
+        // Only allow `error?` which is an OptionalTypeDescriptorNode wrapping an error type
         if (typeNode.kind() == SyntaxKind.OPTIONAL_TYPE_DESC) {
             Node innerType = ((OptionalTypeDescriptorNode) typeNode).typeDescriptor();
             return innerType.kind() == SyntaxKind.ERROR_TYPE_DESC;
         }
-        // Allow `error` alone as well
-        return typeNode.kind() == SyntaxKind.ERROR_TYPE_DESC;
+        return false;
     }
 
     public boolean isFileService(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/file/compiler/FileServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/file/compiler/FileServiceValidator.java
@@ -26,8 +26,11 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.FunctionSignatureNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.OptionalTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.ParameterNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
@@ -113,14 +116,37 @@ public class FileServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
                 reportErrorDiagnostic(functionDefinitionNode.location(), syntaxNodeAnalysisContext,
                         ErrorCodes.FILE_101, value.split(" ")[0]);
             } else if (functionSignatureNode.returnTypeDesc().isPresent()) {
-                reportErrorDiagnostic(functionDefinitionNode.location(), syntaxNodeAnalysisContext,
-                        ErrorCodes.FILE_104, functionName);
+                validateReturnType(functionDefinitionNode, syntaxNodeAnalysisContext, functionName);
             }
         } else {
             reportErrorDiagnostic(functionDefinitionNode.location(), syntaxNodeAnalysisContext,
                     ErrorCodes.FILE_105);
         }
 
+    }
+
+    private void validateReturnType(FunctionDefinitionNode functionDefinitionNode,
+                                    SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, String functionName) {
+        Optional<ReturnTypeDescriptorNode> returnTypeDesc = functionDefinitionNode.functionSignature().returnTypeDesc();
+        if (returnTypeDesc.isEmpty()) {
+            return;
+        }
+        Node typeNode = returnTypeDesc.get().type();
+        if (isErrorOrNilType(typeNode)) {
+            return;
+        }
+        reportErrorDiagnostic(functionDefinitionNode.location(), syntaxNodeAnalysisContext,
+                ErrorCodes.FILE_104, functionName);
+    }
+
+    private boolean isErrorOrNilType(Node typeNode) {
+        // Allow `error?` which is an OptionalTypeDescriptorNode wrapping an error type
+        if (typeNode.kind() == SyntaxKind.OPTIONAL_TYPE_DESC) {
+            Node innerType = ((OptionalTypeDescriptorNode) typeNode).typeDescriptor();
+            return innerType.kind() == SyntaxKind.ERROR_TYPE_DESC;
+        }
+        // Allow `error` alone as well
+        return typeNode.kind() == SyntaxKind.ERROR_TYPE_DESC;
     }
 
     public boolean isFileService(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext) {

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -218,3 +218,14 @@ supported events are
 * On file create
 * On file delete
 * On file modification
+
+Each remote function accepts a `file:FileEvent` parameter and may optionally return `error?`. If no return type is
+specified, the function is treated as returning `()`.
+
+```ballerina
+remote function onCreate(file:FileEvent m) returns error? {
+}
+```
+
+When a remote function returns an error, the error stack trace is printed. The listener continues processing
+subsequent events without terminating.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.12.1-SNAPSHOT
+version=1.13.0-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 testngVersion=7.6.1

--- a/native/src/main/java/io/ballerina/stdlib/file/service/FSListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/file/service/FSListener.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.types.MethodType;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.utils.TypeUtils;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
@@ -61,7 +62,11 @@ public class FSListener implements LocalFileSystemListener {
                     BObject service  = serviceEntry.getKey();
                     ObjectType type = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
                     boolean isConcurrentSafe = type.isIsolated() && type.isIsolated(functionName);
-                    runtime.callMethod(service, functionName, new StrandMetadata(isConcurrentSafe, null), balFileEvent);
+                    Object result = runtime.callMethod(service, functionName,
+                            new StrandMetadata(isConcurrentSafe, null), balFileEvent);
+                    if (result instanceof BError bError) {
+                        bError.printStackTrace();
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-library/issues/7596

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request extends the file listener service to support optional error handling in remote functions. File listener remote functions can now declare an `error?` return type, allowing event handlers to signal failures while the listener continues processing subsequent events.

## Key Changes

**Compiler Plugin & Validation**
- Updated return type validation to explicitly allow `error?` return type in remote functions
- Modified error message to clarify that only `error?` is permitted for returns, replacing the previous blanket prohibition
- Added compiler test case to verify the new functionality works correctly

**Runtime Error Handling**
- Enhanced the native listener to capture and log error returns from remote function invocations
- Errors are logged with stack traces while listener operation continues uninterrupted

**Documentation & Examples**
- Updated README examples to demonstrate the new `returns error?` syntax in remote function handlers
- Added specification documentation detailing the remote function contract, including the optional error return capability and runtime behavior
- Documented that omitting a return type implies the default `()` return

**Project Updates**
- Updated changelog to reflect the new feature
- Incremented version to 1.13.0-SNAPSHOT
- Added comprehensive test resources for validation scenarios

The changes maintain backward compatibility—existing remote functions without return types continue to work as before, while developers can now optionally enable error signaling in their file event handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->